### PR TITLE
Simplify theme toggle to 2-state brilliant/fantastic pill slider

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -232,7 +232,7 @@
 .nav-merged #theme-toggle-nav,
 .nav-merged #theme-toggle-nav-mobile {
   opacity: 1;
-  max-width: 150px;
+  max-width: 120px;
   overflow: visible;
   transform: scale(1);
   pointer-events: auto;
@@ -291,6 +291,23 @@
 .nav-morph-no-transition #theme-toggle-nav-mobile {
   transition: none !important;
   animation: none !important;
+}
+
+/* Fantastic: springy indicator slide + glow */
+[data-theme="fantastic"] .theme-toggle-indicator {
+  transition: left 400ms cubic-bezier(0.34, 1.56, 0.64, 1);
+  box-shadow: 0 0 12px 2px var(--color-sparkle, oklch(80% 0.15 80));
+}
+
+/* Fantastic: smile icon wiggles on hover */
+[data-theme="fantastic"] .theme-toggle button:last-child .size-4 {
+  animation: toggle-icon-wiggle 2s ease-in-out infinite;
+}
+
+@keyframes toggle-icon-wiggle {
+  0%, 100% { transform: rotate(0deg); }
+  25% { transform: rotate(8deg); }
+  75% { transform: rotate(-8deg); }
 }
 
 /* This file is for your main application CSS */

--- a/lib/bf_web/components/layouts.ex
+++ b/lib/bf_web/components/layouts.ex
@@ -124,19 +124,11 @@ defmodule BrilliantFantasticWeb.Layouts do
   """
   def theme_toggle(assigns) do
     ~H"""
-    <div class="card relative flex flex-row items-center border-2 border-base-300 bg-base-300 rounded-full">
-      <div class="absolute w-1/3 h-full rounded-full border-1 border-base-200 bg-base-100 brightness-200 left-0 [[data-theme=brilliant]_&]:left-1/3 [[data-theme=fantastic]_&]:left-2/3 transition-[left]" />
+    <div class="theme-toggle card relative flex flex-row items-center border-2 border-base-300 bg-base-300 rounded-full">
+      <div class="theme-toggle-indicator absolute w-1/2 h-full rounded-full border-1 border-base-200 bg-base-100 brightness-200 left-0 [[data-theme=fantastic]_&]:left-1/2 transition-[left]" />
 
       <button
-        class="flex p-2 cursor-pointer w-1/3"
-        phx-click={JS.dispatch("phx:set-theme")}
-        data-phx-theme="system"
-      >
-        <.icon name="hero-swatch-solid" class="size-4 opacity-75 hover:opacity-100" />
-      </button>
-
-      <button
-        class="flex p-2 cursor-pointer w-1/3"
+        class="flex p-2 cursor-pointer w-1/2"
         phx-click={JS.dispatch("phx:set-theme")}
         data-phx-theme="brilliant"
       >
@@ -144,7 +136,7 @@ defmodule BrilliantFantasticWeb.Layouts do
       </button>
 
       <button
-        class="flex p-2 cursor-pointer w-1/3"
+        class="flex p-2 cursor-pointer w-1/2"
         phx-click={JS.dispatch("phx:set-theme")}
         data-phx-theme="fantastic"
       >

--- a/lib/bf_web/components/layouts/root.html.heex
+++ b/lib/bf_web/components/layouts/root.html.heex
@@ -296,23 +296,21 @@
           if (existing) existing.remove();
         };
 
+        window.__themeDirection = null;
+
         const setTheme = (theme) => {
-          if (theme === "system") {
-            localStorage.removeItem("phx:theme");
-            document.documentElement.removeAttribute("data-theme");
-            clearPalette();
-          } else {
-            localStorage.setItem("phx:theme", theme);
-            document.documentElement.setAttribute("data-theme", theme);
-            if (theme === "fantastic") applyRandomPalettes();
-            else clearPalette();
-          }
+          const prev = document.documentElement.getAttribute("data-theme");
+          window.__themeDirection = (theme === "fantastic") ? "to-fantastic" : "to-brilliant";
+          localStorage.setItem("phx:theme", theme);
+          document.documentElement.setAttribute("data-theme", theme);
+          if (theme === "fantastic") applyRandomPalettes();
+          else clearPalette();
         };
 
         if (!document.documentElement.hasAttribute("data-theme")) {
-          setTheme(localStorage.getItem("phx:theme") || "system");
+          setTheme(localStorage.getItem("phx:theme") || "brilliant");
         }
-        window.addEventListener("storage", (e) => e.key === "phx:theme" && setTheme(e.newValue || "system"));
+        window.addEventListener("storage", (e) => e.key === "phx:theme" && setTheme(e.newValue || "brilliant"));
         window.addEventListener("phx:set-theme", (e) => setTheme(e.target.dataset.phxTheme));
       })();
     </script>

--- a/lib/bf_web/live/home_live.html.heex
+++ b/lib/bf_web/live/home_live.html.heex
@@ -106,6 +106,74 @@
     } catch (_) {}
   }
 
+  // Clean precise click for brilliant
+  function playBrilliantSound() {
+    try {
+      const ctx = getAudioContext();
+      if (ctx.state === "suspended") ctx.resume();
+      const now = ctx.currentTime;
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.type = "sine";
+      osc.frequency.setValueAtTime(1200, now);
+      osc.frequency.exponentialRampToValueAtTime(800, now + 0.06);
+      gain.gain.setValueAtTime(0.12, now);
+      gain.gain.exponentialRampToValueAtTime(0.001, now + 0.08);
+      osc.connect(gain).connect(ctx.destination);
+      osc.start(now); osc.stop(now + 0.1);
+    } catch (_) {}
+  }
+
+  // Playful ascending boing for fantastic
+  function playFantasticSound() {
+    try {
+      const ctx = getAudioContext();
+      if (ctx.state === "suspended") ctx.resume();
+      const now = ctx.currentTime;
+      // Main tone: ascending sweep
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.type = "sine";
+      osc.frequency.setValueAtTime(400, now);
+      osc.frequency.exponentialRampToValueAtTime(1200, now + 0.1);
+      osc.frequency.exponentialRampToValueAtTime(800, now + 0.2);
+      gain.gain.setValueAtTime(0.15, now);
+      gain.gain.exponentialRampToValueAtTime(0.001, now + 0.25);
+      osc.connect(gain).connect(ctx.destination);
+      osc.start(now); osc.stop(now + 0.3);
+      // Sparkle overtone
+      const osc2 = ctx.createOscillator();
+      const gain2 = ctx.createGain();
+      osc2.type = "triangle";
+      osc2.frequency.setValueAtTime(2000, now + 0.05);
+      osc2.frequency.exponentialRampToValueAtTime(3000, now + 0.15);
+      gain2.gain.setValueAtTime(0.06, now + 0.05);
+      gain2.gain.exponentialRampToValueAtTime(0.001, now + 0.2);
+      osc2.connect(gain2).connect(ctx.destination);
+      osc2.start(now + 0.05); osc2.stop(now + 0.25);
+    } catch (_) {}
+  }
+
+  // Sparkle burst from toggle element when switching to fantastic
+  function spawnToggleBurst(el) {
+    const rect = el.getBoundingClientRect();
+    const cx = rect.left + rect.width / 2;
+    const cy = rect.top + rect.height / 2;
+    for (let i = 0; i < 6; i++) {
+      const sparkle = document.createElement("div");
+      sparkle.className = "morph-particle";
+      sparkle.innerHTML = `<svg viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path d="${SPARKLE_PATH}" /></svg>`;
+      sparkle.style.left = cx + "px";
+      sparkle.style.top = cy + "px";
+      const angle = (Math.PI * 2 * i) / 6 + (Math.random() - 0.5) * 0.5;
+      const distance = 20 + Math.random() * 30;
+      sparkle.style.setProperty("--tx", Math.cos(angle) * distance + "px");
+      sparkle.style.setProperty("--ty", Math.sin(angle) * distance + "px");
+      document.body.appendChild(sparkle);
+      sparkle.addEventListener("animationend", () => sparkle.remove());
+    }
+  }
+
   // Spawn particle burst from the floating toggle position
   function spawnParticleBurst() {
     const floatEl = document.getElementById("theme-toggle-float");
@@ -141,6 +209,17 @@
       // Warm up audio on first interaction
       document.addEventListener("click", warmUpAudio, { once: true });
       document.addEventListener("touchstart", warmUpAudio, { once: true });
+
+      // Listen for theme toggle clicks
+      window.addEventListener("phx:set-theme", (e) => {
+        const theme = e.target.dataset.phxTheme;
+        if (theme === "fantastic") {
+          playFantasticSound();
+          spawnToggleBurst(e.target.closest(".theme-toggle") || e.target);
+        } else if (theme === "brilliant") {
+          playBrilliantSound();
+        }
+      });
 
       const sentinel = document.getElementById("nav-sentinel");
       if (!sentinel) return;


### PR DESCRIPTION
## Summary

- Replaced the 3-state (system/brilliant/fantastic) toggle with a 2-state pill slider — brilliant (scale icon) on left, fantastic (smile icon) on right
- Added per-theme toggle personality: brilliant gets a clean click sound; fantastic gets a springy bounce transition, boing sound with sparkle overtone, 6-particle sparkle burst, indicator glow, and wiggling smile icon
- Removed the "system" theme option entirely, defaulting to "brilliant"

## Test plan

- [ ] Load page — toggle shows 2 icons (scale + smile), indicator on left (brilliant)
- [ ] Click fantastic — indicator bounces right with overshoot, sparkle burst, boing sound, palettes apply
- [ ] Click brilliant — indicator slides cleanly left, click sound, palettes clear
- [ ] Scroll down — toggle morphs into nav (existing behavior preserved)
- [ ] Refresh — defaults to last selected theme (localStorage)
- [ ] Verify no "system" option anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)