### PR TITLE
Migrate Gigalixir app to bf, configurable contact emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This application is deployed to [Gigalixir](https://gigalixir.com) using buildpa
 
 The application is automatically deployed to production when code is merged into the `main` branch. CI must pass before deployment is triggered.
 
-The production application lives at https://brilliantfantastic.gigalixirapp.com.
+The production application lives at https://bf.gigalixirapp.com.
 
 ### Manual deployment
 
@@ -74,7 +74,7 @@ gigalixir login
 3. Add the git remote
 
 ```
-gigalixir git:remote brilliantfantastic
+gigalixir git:remote bf
 ```
 
 4. Deploy

--- a/config/config.exs
+++ b/config/config.exs
@@ -10,7 +10,11 @@ import Config
 config :bf,
   namespace: BrilliantFantastic,
   ecto_repos: [BrilliantFantastic.Repo],
-  generators: [timestamp_type: :utc_datetime]
+  generators: [timestamp_type: :utc_datetime],
+  contact_to_email: "me@bf.lol",
+  contact_to_name: "Jamie Wright",
+  contact_from_email: "noreply@bf.lol",
+  contact_from_name: "Contact Form"
 
 # Configure the endpoint
 config :bf, BrilliantFantasticWeb.Endpoint,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -57,6 +57,16 @@ if config_env() == :prod do
 
   config :bf, :dns_cluster_query, System.get_env("DNS_CLUSTER_QUERY")
 
+  for {key, env} <- [
+        contact_to_email: "CONTACT_TO_EMAIL",
+        contact_to_name: "CONTACT_TO_NAME",
+        contact_from_email: "CONTACT_FROM_EMAIL",
+        contact_from_name: "CONTACT_FROM_NAME"
+      ],
+      value = System.get_env(env) do
+    config :bf, [{key, value}]
+  end
+
   config :bf, BrilliantFantasticWeb.Endpoint,
     url: [host: host, port: 443, scheme: "https"],
     http: [

--- a/lib/bf/contact_notifier.ex
+++ b/lib/bf/contact_notifier.ex
@@ -8,14 +8,19 @@ defmodule BrilliantFantastic.ContactNotifier do
   alias BrilliantFantastic.Mailer
 
   def deliver_contact_message(%BrilliantFantastic.ContactForm{} = contact) do
+    to_email = Application.get_env(:bf, :contact_to_email)
+    to_name = Application.get_env(:bf, :contact_to_name)
+    from_email = Application.get_env(:bf, :contact_from_email)
+    from_name = Application.get_env(:bf, :contact_from_name)
+
     subject_line =
       if contact.subject && contact.subject != "",
         do: contact.subject,
-        else: "Message from #{contact.email} on brilliantfantastic.com"
+        else: "Message from #{contact.email} on #{domain(to_email)}"
 
     new()
-    |> to({"Jamie Wright", "me@brilliantfantastic.com"})
-    |> from({"Contact Form", "noreply@brilliantfantastic.com"})
+    |> to({to_name, to_email})
+    |> from({from_name, from_email})
     |> reply_to({contact.name, contact.email})
     |> subject(subject_line)
     |> text_body("""
@@ -25,4 +30,6 @@ defmodule BrilliantFantastic.ContactNotifier do
     """)
     |> Mailer.deliver()
   end
+
+  defp domain(email), do: email |> String.split("@") |> List.last()
 end

--- a/test/bf/contact_notifier_test.exs
+++ b/test/bf/contact_notifier_test.exs
@@ -17,7 +17,7 @@ defmodule BrilliantFantastic.ContactNotifierTest do
     test "delivers email to the site owner" do
       ContactNotifier.deliver_contact_message(@contact)
 
-      assert_email_sent(to: [{"Jamie Wright", "me@brilliantfantastic.com"}])
+      assert_email_sent(to: [{"Jamie Wright", "me@bf.lol"}])
     end
 
     test "sets reply-to as the sender's name and email" do
@@ -36,7 +36,7 @@ defmodule BrilliantFantastic.ContactNotifierTest do
       contact = %{@contact | subject: nil}
       ContactNotifier.deliver_contact_message(contact)
 
-      assert_email_sent(subject: "Message from ada@example.com on brilliantfantastic.com")
+      assert_email_sent(subject: "Message from ada@example.com on bf.lol")
     end
 
     test "includes the sender's name, email, and message in the body" do
@@ -52,7 +52,7 @@ defmodule BrilliantFantastic.ContactNotifierTest do
     test "sends from the noreply address" do
       ContactNotifier.deliver_contact_message(@contact)
 
-      assert_email_sent(from: {"Contact Form", "noreply@brilliantfantastic.com"})
+      assert_email_sent(from: {"Contact Form", "noreply@bf.lol"})
     end
   end
 end


### PR DESCRIPTION
## Summary
- Updates Gigalixir app references from `brilliantfantastic` to `bf`
- Makes contact notifier email addresses configurable via app config with env var overrides (`CONTACT_TO_EMAIL`, `CONTACT_TO_NAME`, `CONTACT_FROM_EMAIL`, `CONTACT_FROM_NAME`)
- Updates README deployment instructions to match new app name

## Before merging
- [x] Create `bf` app on Gigalixir: `gigalixir apps:create -n bf`
- [x] Create database: `gigalixir pg:create -a bf --free`
- [x] Copy env vars from old app to new app
- [x] Update `GIGALIXIR_APP_NAME` GitHub Actions secret to `bf`
- [ ] Set up DNS for `bf.lol`
- [ ] Verify deployment to new app works
- [x] Delete old app: `gigalixir apps:destroy -a brilliantfantastic`

🤖 Generated with [Claude Code](https://claude.com/claude-code)